### PR TITLE
Add Python script for ChatGPT environment command line

### DIFF
--- a/articles/turn-chatgpt-linux-command-line-actually-useful-ai-djjic/chatgpt_environment_command_line.py
+++ b/articles/turn-chatgpt-linux-command-line-actually-useful-ai-djjic/chatgpt_environment_command_line.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import getpass
+import socket
+import shlex
+
+# Example user input command
+input_data = "ls -l /"
+
+# Get Environmental Variables for prompt
+username = getpass.getuser()  # Get the current username
+hostname = socket.gethostname()  # Get the current hostname
+prompt = f"{username}@{hostname}$ "
+
+try:
+    command_results = subprocess.run(
+        input_data,
+        shell=True,
+        capture_output=True,
+        text=True
+    )
+
+    # Display the results
+    print(command_results.stdout, end="")  # Print standard output
+
+    if command_results.stderr:
+        print(command_results.stderr, end="")  # Print error output if any
+
+except Exception as e:
+    print(f"Error executing command: {e}")
+
+# Print the prompt
+print(prompt)


### PR DESCRIPTION
## Summary
- add `chatgpt_environment_command_line.py` in the command-line article folder

## Testing
- `python3 articles/turn-chatgpt-linux-command-line-actually-useful-ai-djjic/chatgpt_environment_command_line.py`
