### PR TITLE
Enhance vectorization script CLI

### DIFF
--- a/articles/3-ways-to-code-all-frustrating/potrace_vectorize.py
+++ b/articles/3-ways-to-code-all-frustrating/potrace_vectorize.py
@@ -1,12 +1,30 @@
-import sys
+#!/usr/bin/env python3
+
+"""Utility to vectorize a JPEG using the potrace library."""
+
+import argparse
 import os
-import potrace
+import sys
+
 from PIL import Image
 import numpy as np
+import potrace
 
 
-def jpeg_to_svg(jpeg_path: str, svg_path: str, threshold: int = 128):
-    """Convert a JPEG image to an SVG using potrace."""
+def jpeg_to_svg(jpeg_path: str, svg_path: str, threshold: int = 128, *, fill: str = "black"):
+    """Convert a JPEG image to an SVG using potrace.
+
+    Parameters
+    ----------
+    jpeg_path: str
+        Path to the source JPEG image.
+    svg_path: str
+        Output SVG file path.
+    threshold: int, optional
+        Grayscale threshold (0-255) for binarization.
+    fill: str, optional
+        Fill color used for the generated path.
+    """
     # Load image and convert to grayscale
     image = Image.open(jpeg_path).convert('L')
     # Binarize image using threshold
@@ -36,19 +54,44 @@ def jpeg_to_svg(jpeg_path: str, svg_path: str, threshold: int = 128):
                     c1, c2 = segment.c1, segment.c2
                     end = segment.end_point
                     f.write(f'C{c1.x},{c1.y} {c2.x},{c2.y} {end.x},{end.y} ')
-            # Close the path
-            f.write('Z" fill="black"/>\n')
+            # Close the path and apply fill color
+            f.write(f'Z" fill="{fill}"/>\n')
         f.write('</svg>\n')
 
 
-def main():
-    if len(sys.argv) < 2:
-        print('Usage: python potrace_vectorize.py <input.jpeg> [output.svg]')
-        sys.exit(1)
-    jpeg_path = sys.argv[1]
-    svg_path = sys.argv[2] if len(sys.argv) > 2 else os.path.splitext(jpeg_path)[0] + '.svg'
-    jpeg_to_svg(jpeg_path, svg_path)
-    print(f'SVG written to {svg_path}')
+def main() -> None:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description="Convert a JPEG image to an SVG using potrace",
+    )
+    parser.add_argument("jpeg_path", help="Input JPEG file")
+    parser.add_argument(
+        "svg_path",
+        nargs="?",
+        help="Output SVG file (defaults to input name with .svg)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=128,
+        help="Grayscale threshold used for binarization",
+    )
+    parser.add_argument(
+        "--fill",
+        default="black",
+        help="Fill color for the generated path",
+    )
+
+    args = parser.parse_args()
+
+    svg_path = args.svg_path or os.path.splitext(args.jpeg_path)[0] + ".svg"
+    jpeg_to_svg(
+        args.jpeg_path,
+        svg_path,
+        threshold=args.threshold,
+        fill=args.fill,
+    )
+    print(f"SVG written to {svg_path}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- improve `potrace_vectorize.py` with a shebang and argparse CLI
- allow specifying threshold and fill color

## Testing
- `python -m py_compile articles/3-ways-to-code-all-frustrating/potrace_vectorize.py`
- `python articles/3-ways-to-code-all-frustrating/potrace_vectorize.py articles/3-ways-to-code-all-frustrating/schoolsone_logo.jpeg test.svg --threshold 128 --fill blue`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e4328fc0c8326a7df29ce7daca592